### PR TITLE
feat(me): add missing track endpoints

### DIFF
--- a/src/lib/me/MeManager.ts
+++ b/src/lib/me/MeManager.ts
@@ -102,7 +102,7 @@ export class MeManager extends Manager {
    * @description Save multiple tracks by ID. (required scropes: user-library-read).
    * @param {string} ids Array of IDs.
    */
-  async saveTracks(ids: string[]) {
+  async saveTracks(ids: string[]): Promise<void> {
     await this.http.put(`/me/tracks`, {
       ids
     });
@@ -112,7 +112,7 @@ export class MeManager extends Manager {
    * @description Remove multiple saved tracks by ID. (required scropes: user-library-read).
    * @param {string} ids Array of IDs.
    */
-  async unsaveTracks(ids: string[]) {
+  async unsaveTracks(ids: string[]): Promise<void> {
     await this.http.delete(`/me/tracks`, {
       query: { ids: ids.join(', ') }
     });

--- a/src/lib/me/MeManager.ts
+++ b/src/lib/me/MeManager.ts
@@ -84,4 +84,37 @@ export class MeManager extends Manager {
 
     return json as CursorPagingObject<RecentlyPlayed>;
   }
+
+  /**
+   * @description Check if one or more tracks is saved in the current user's library. (required scropes: user-library-read).
+   * @returns {Promise<UserPrivate>}
+   * @returns {Promise<boolean[]>} Returns a promise with the an array of booleans.
+   */
+  async containTracks(ids: string[]): Promise<boolean[]> {
+    const res = await this.http.get(`/me/tracks/contains`, {
+      query: { ids: ids.join(', ') }
+    });
+
+    return res.data as boolean[];
+  }
+
+  /**
+   * @description Save multiple tracks by ID. (required scropes: user-library-read).
+   * @param {string} ids Array of IDs.
+   */
+  async saveTracks(ids: string[]) {
+    await this.http.put(`/me/tracks`, {
+      ids
+    });
+  }
+
+  /**
+   * @description Remove multiple saved tracks by ID. (required scropes: user-library-read).
+   * @param {string} ids Array of IDs.
+   */
+  async unsaveTracks(ids: string[]) {
+    await this.http.delete(`/me/tracks`, {
+      query: { ids: ids.join(', ') }
+    });
+  }
 }

--- a/src/lib/me/MeManager.ts
+++ b/src/lib/me/MeManager.ts
@@ -87,12 +87,11 @@ export class MeManager extends Manager {
 
   /**
    * @description Check if one or more tracks is saved in the current user's library. (required scropes: user-library-read).
-   * @returns {Promise<UserPrivate>}
    * @returns {Promise<boolean[]>} Returns a promise with the an array of booleans.
    */
   async containTracks(ids: string[]): Promise<boolean[]> {
     const res = await this.http.get(`/me/tracks/contains`, {
-      query: { ids: ids.join(', ') }
+      query: { ids: ids.join(',') }
     });
 
     return res.data as boolean[];
@@ -114,7 +113,7 @@ export class MeManager extends Manager {
    */
   async unsaveTracks(ids: string[]): Promise<void> {
     await this.http.delete(`/me/tracks`, {
-      query: { ids: ids.join(', ') }
+      query: { ids: ids.join(',') }
     });
   }
 }


### PR DESCRIPTION
adds [Check user's saved tracks](https://developer.spotify.com/documentation/web-api/reference/#/operations/check-users-saved-tracks), [Save tracks for current user](https://developer.spotify.com/documentation/web-api/reference/#/operations/save-tracks-user) and [Remove tracks for current user](https://developer.spotify.com/documentation/web-api/reference/#/operations/remove-tracks-user)